### PR TITLE
83 elapsedtime

### DIFF
--- a/TGC.Core/Example/TgcExample.cs
+++ b/TGC.Core/Example/TgcExample.cs
@@ -25,7 +25,7 @@ namespace TGC.Core.Example
             FPS = true;
             Camara = new TgcCamera();
             ElapsedTime = -1;
-            HighResolutionTimer = new HighResolutionTimer();
+            Timer = new HighResolutionTimer();
             Frustum = new TgcFrustum();
             //DirectSound = new TgcDirectSound(); Por ahora se carga por afuera
             DrawText = new TgcText2D();
@@ -87,7 +87,7 @@ namespace TGC.Core.Example
         /// </summary>
         public TgcCamera Camara { get; set; }
 
-        private HighResolutionTimer HighResolutionTimer { get; }
+        private HighResolutionTimer Timer { get; }
 
         public TgcFrustum Frustum { get; set; }
 
@@ -157,8 +157,8 @@ namespace TGC.Core.Example
         /// </summary>
         protected void UpdateClock()
         {
-            ElapsedTime = HighResolutionTimer.FrameTime;
-            HighResolutionTimer.Set();
+            ElapsedTime = Timer.FrameTime;
+            Timer.Set();
         }
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace TGC.Core.Example
         {
             if (FPS)
             {
-                DrawText.drawText(HighResolutionTimer.FramesPerSecondText(), 0, 0, Color.Yellow);
+                DrawText.drawText(Timer.FramesPerSecondText(), 0, 0, Color.Yellow);
             }
         }
 
@@ -266,7 +266,7 @@ namespace TGC.Core.Example
 
         public void ResetTimer()
         {
-            HighResolutionTimer.Reset();
+            Timer.Reset();
         }
 
         /// <summary>

--- a/TGC.Core/HighResolutionTimer.cs
+++ b/TGC.Core/HighResolutionTimer.cs
@@ -16,6 +16,15 @@ namespace TGC.Core
         // Members
         private long _startTime;
 
+        // Constructors
+        /// <summary>
+        ///     Creates a new HighResolutionTimer
+        /// </summary>
+        public HighResolutionTimer()
+        {
+            this._startTime = Ticks;
+        }
+
         /// <summary>
         ///     Gets the frequency that all timers performs at.
         /// </summary>

--- a/TGC.Core/HighResolutionTimer.cs
+++ b/TGC.Core/HighResolutionTimer.cs
@@ -7,13 +7,9 @@ namespace TGC.Core
     /// </summary>
     public class HighResolutionTimer
     {
-        // Static Members
         private int _fps;
-
         private int _frameCount;
         private float _frameSecond;
-
-        // Members
         private long _startTime;
 
         // Constructors
@@ -22,7 +18,7 @@ namespace TGC.Core
         /// </summary>
         public HighResolutionTimer()
         {
-            this._startTime = Ticks;
+            Reset();
         }
 
         /// <summary>
@@ -32,9 +28,7 @@ namespace TGC.Core
         {
             get
             {
-                long freq = 0;
-                QueryPerformanceFrequency(out freq);
-
+                QueryPerformanceFrequency(out var freq);
                 return freq;
             }
         }
@@ -46,14 +40,10 @@ namespace TGC.Core
         {
             get
             {
-                long ticks = 0;
-                QueryPerformanceCounter(out ticks);
-
+                QueryPerformanceCounter(out var ticks);
                 return ticks;
             }
         }
-
-        // Properties
 
         /// <summary>
         ///     Gets the time recorded between frames.


### PR DESCRIPTION
Arreglado primer ElapsedTime. Ahora viene el valor `0` en vez de un valor muy alto.
Además, se cambió el nombre del atributo `HighResolutionTimer` en la clase `TgcExample` porque era igual al nombre de la clase.