### PR TITLE
Fixed Quaternion identity and example, and added a trackball example

### DIFF
--- a/TGC.Core/Mathematica/TGCQuaternion.cs
+++ b/TGC.Core/Mathematica/TGCQuaternion.cs
@@ -74,7 +74,8 @@ namespace TGC.Core.Mathematica
         /// </summary>
         public static TGCQuaternion Identity
         {
-            get { return new TGCQuaternion(1f, 1f, 1f, 1f); }
+            get { return new TGCQuaternion(Quaternion.Identity); }
+            
         }
 
         /// <summary>

--- a/TGC.Examples/TGC.Examples.csproj
+++ b/TGC.Examples/TGC.Examples.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Lights\EjemploPointLight.cs" />
     <Compile Include="Lights\EjemploSpotLight.cs" />
     <Compile Include="MathExamples\EjemploMatematicaVarios.cs" />
+    <Compile Include="Transformations\EjemploTrackball.cs" />
     <Compile Include="Transformations\EjemploTransformaciones.cs" />
     <Compile Include="MeshExamples\EjemploTriangulosYPlanos.cs" />
     <Compile Include="Optimization\GrillaRegular\EjemploGrillaRegular.cs" />

--- a/TGC.Examples/Transformations/EjemploQuaternions.cs
+++ b/TGC.Examples/Transformations/EjemploQuaternions.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using TGC.Core.Direct3D;
 using TGC.Core.Geometry;
 using TGC.Core.Mathematica;
+using TGC.Core.SceneLoader;
 using TGC.Core.Textures;
 using TGC.Examples.Example;
 using TGC.Examples.UserControls;
@@ -17,8 +18,12 @@ namespace TGC.Examples.Transformations
     {
         private TGCVertex3fModifier rotacionModifier;
 
-        private TGCBox boxEuler;
-        private TGCBox boxTGCQuaternion;
+        private TGCMatrix baseScaleRotation;
+        private TGCMatrix baseEulerTranslation;
+        private TGCMatrix baseQuaternionTranslation;
+
+        private TgcMesh eulerMesh;
+        private TgcMesh quaternionMesh;
 
         public EjemploTGCQuaternions(string mediaDir, string shadersDir, TgcUserVars userVars, Panel modifiersPanel)
             : base(mediaDir, shadersDir, userVars, modifiersPanel)
@@ -30,16 +35,20 @@ namespace TGC.Examples.Transformations
 
         public override void Init()
         {
-            var textureEuler = TgcTexture.createTexture(D3DDevice.Instance.Device, MediaDir + "Texturas\\madera.jpg");
-            boxEuler = TGCBox.fromSize(new TGCVector3(-50, 0, 0), new TGCVector3(50, 50, 50), textureEuler);
+            var loader = new TgcSceneLoader();
+            TgcScene scene = loader.loadSceneFromFile(MediaDir + "\\XWing\\xwing-TgcScene.xml");
 
-            var textureQuat = TgcTexture.createTexture(D3DDevice.Instance.Device,
-                MediaDir + "Texturas\\paredMuyRugosa.jpg");
-            boxTGCQuaternion = TGCBox.fromSize(new TGCVector3(50, 0, 0), new TGCVector3(50, 50, 50), textureQuat);
+            eulerMesh = scene.Meshes[0];
+            quaternionMesh = scene.Meshes[0].clone("quat");
+
+            baseEulerTranslation = TGCMatrix.Translation(new TGCVector3(-10.0f, 0.0f, 0.0f));
+            baseQuaternionTranslation = TGCMatrix.Translation(new TGCVector3(10.0f, 0.0f, 0.0f));
 
             rotacionModifier = AddVertex3f("Rotacion", TGCVector3.Empty, new TGCVector3(360, 360, 360), TGCVector3.Empty);
 
-            Camara.SetCamera(new TGCVector3(0f, 1f, -200f), new TGCVector3(0f, 1f, 500f));
+            baseScaleRotation = TGCMatrix.Scaling(new TGCVector3(0.05f, 0.05f, 0.05f)) * TGCMatrix.RotationY(FastMath.PI_HALF);
+
+            Camara.SetCamera(new TGCVector3(0f, 1f, -25f), new TGCVector3(0f, 1f, 200f));
         }
 
         public override void Update()
@@ -52,12 +61,20 @@ namespace TGC.Examples.Transformations
             rot.Z = Geometry.DegreeToRadian(rot.Z);
 
             //Rotacion Euler
-            boxEuler.Transform = TGCMatrix.RotationYawPitchRoll(rot.Y, rot.X, rot.Z) *
-                                 TGCMatrix.Translation(boxEuler.Position);
+            eulerMesh.Transform = baseScaleRotation *
+                TGCMatrix.RotationYawPitchRoll(rot.Y, rot.X, rot.Z) *
+                baseEulerTranslation;
 
             //Rotacion TGCQuaternion
-            var q = TGCQuaternion.RotationYawPitchRoll(rot.Y, rot.X, rot.Z);
-            boxTGCQuaternion.Transform = TGCMatrix.RotationTGCQuaternion(q) * TGCMatrix.Translation(boxTGCQuaternion.Position);
+            TGCQuaternion rotationX = TGCQuaternion.RotationAxis(new TGCVector3(1.0f, 0.0f, 0.0f), rot.X);
+            TGCQuaternion rotationY = TGCQuaternion.RotationAxis(new TGCVector3(0.0f, 1.0f, 0.0f), rot.Y);
+            TGCQuaternion rotationZ = TGCQuaternion.RotationAxis(new TGCVector3(0.0f, 0.0f, 1.0f), rot.Z);
+
+            TGCQuaternion rotation = rotationX * rotationY * rotationZ;
+
+            quaternionMesh.Transform = baseScaleRotation * 
+                TGCMatrix.RotationTGCQuaternion(rotation) * 
+                baseQuaternionTranslation;
 
             PostUpdate();
         }
@@ -66,16 +83,16 @@ namespace TGC.Examples.Transformations
         {
             PreRender();
 
-            boxEuler.Render();
-            boxTGCQuaternion.Render();
+            eulerMesh.Render();
+            quaternionMesh.Render();
 
             PostRender();
         }
 
         public override void Dispose()
         {
-            boxEuler.Dispose();
-            boxTGCQuaternion.Dispose();
+            eulerMesh.Dispose();
+            quaternionMesh.Dispose();
         }
     }
 }

--- a/TGC.Examples/Transformations/EjemploTrackball.cs
+++ b/TGC.Examples/Transformations/EjemploTrackball.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using TGC.Core.BoundingVolumes;
+using TGC.Core.Collision;
+using TGC.Core.Direct3D;
+using TGC.Core.Geometry;
+using TGC.Core.Input;
+using TGC.Core.Mathematica;
+using TGC.Core.SceneLoader;
+using TGC.Core.Shaders;
+using TGC.Core.Textures;
+using TGC.Examples.Example;
+using TGC.Examples.UserControls;
+
+namespace TGC.Examples.Transformations
+{
+    /// <summary>
+    ///     Trackball usando Quaternions
+    /// </summary>
+    public class EjemploTrackball : TGCExampleViewer
+    {
+        private readonly float radius = 10.0f;
+
+        private TGCQuaternion stacked;
+        private TGCMatrix baseSharkTransform;
+
+        private TgcBoundingSphere boundingSphere;
+
+        private TGCSphere sphere;
+        private TgcMesh shark;
+
+        private TgcPickingRay pickingRay;
+
+        private TGCVector3 fromDrag;
+        private TGCVector3 normalizedFrom;
+        private TGCVector3 currentPick;
+        private bool dragging;
+
+        private TgcArrow fromArrow;
+        private TgcArrow toArrow;
+        private TgcArrow crossArrow;
+
+        public EjemploTrackball(string mediaDir, string shadersDir, TgcUserVars userVars, Panel modifiersPanel)
+            : base(mediaDir, shadersDir, userVars, modifiersPanel)
+        {
+            Category = "Transformations";
+            Name = "Trackball usando Quaternion";
+            Description = "Trackball usando Quaternion";
+        }
+
+        public override void Init()
+        {
+            stacked = TGCQuaternion.Identity;
+            fromDrag = TGCVector3.Empty;
+            dragging = false;
+            currentPick = TGCVector3.Empty;
+
+            InitializeSphere();
+            InitializeShark();
+            InitializeArrows();
+
+            pickingRay = new TgcPickingRay(Input);
+
+            Camara.SetCamera(new TGCVector3(20f, 0f, 20f), new TGCVector3(-1f, 0f, -1f));
+        }
+
+
+        public override void Update()
+        {
+            PreUpdate();
+
+            currentPick = PerformPicking();
+
+            if(PickingInsideSphere())
+            {
+                if (dragging)
+                {
+                    TGCVector3 normalizedTo = currentPick;
+                    normalizedTo.Normalize();
+
+                    var cross = TGCVector3.Cross(normalizedFrom, normalizedTo);
+                    var newRotation = TGCQuaternion.RotationAxis(cross, FastMath.Acos(TGCVector3.Dot(normalizedFrom, normalizedTo)));
+                    var currentRotation = TGCQuaternion.Multiply(stacked, newRotation);
+
+                    shark.Transform = baseSharkTransform * TGCMatrix.RotationTGCQuaternion(currentRotation);
+
+                    if (Input.buttonUp(TgcD3dInput.MouseButtons.BUTTON_LEFT))
+                    {
+                        stacked = currentRotation;
+                        shark.Transform = baseSharkTransform * TGCMatrix.RotationTGCQuaternion(stacked);
+                        dragging = false;
+                    }
+                }
+                else if (Input.buttonPressed(TgcD3dInput.MouseButtons.BUTTON_LEFT))
+                {
+                    dragging = true;
+                    fromDrag = currentPick;
+                    normalizedFrom = TGCVector3.Normalize(fromDrag);
+                }
+            }
+
+            UpdateArrows();
+
+            PostUpdate();
+        }
+
+        public override void Render()
+        {
+            PreRender();
+            shark.Render();
+            fromArrow.Render();
+            toArrow.Render();
+            crossArrow.Render();
+            sphere.Render();
+            PostRender();
+        }
+
+        public override void Dispose()
+        {
+            boundingSphere.Dispose();
+            sphere.Dispose();
+            shark.Dispose();
+        }
+
+        private bool PickingInsideSphere()
+        {
+            return currentPick.LengthSq() > 0.0f;
+        }
+
+
+
+
+        private TGCVector3 PerformPicking()
+        {
+            pickingRay.updateRay();
+            var ray = pickingRay.Ray;
+            float distance = 0.0f;
+            TGCVector3 point = TGCVector3.Empty;
+            TgcCollisionUtils.intersectRaySphere(ray, boundingSphere, out distance, out point);
+            return point;
+        }
+
+        private void InitializeShark()
+        {
+            var loader = new TgcSceneLoader();
+            var scene = loader.loadSceneFromFile(MediaDir + "Aquatic\\Meshes\\shark-TgcScene.xml");
+            shark = scene.Meshes[0];
+
+            TGCVector3 rotationDirection = TGCVector3.Up;
+            rotationDirection.Normalize();
+            float angle = FastMath.QUARTER_PI / 2.0f;
+
+            baseSharkTransform = TGCMatrix.Scaling(new TGCVector3(0.08f, 0.08f, 0.08f)) * TGCMatrix.RotationTGCQuaternion(new TGCQuaternion(0.0f, FastMath.Sin(angle), 0.0f, FastMath.Cos(angle)));
+
+            shark.Transform = baseSharkTransform;
+        }
+
+        private void InitializeSphere()
+        {
+            var transparentTexture = TgcTexture.createTexture(D3DDevice.Instance.Device, MediaDir + "Texturas\\transparent.png");
+
+            boundingSphere = new TgcBoundingSphere(TGCVector3.Empty, radius);
+
+            sphere = new TGCSphere(1.0f, transparentTexture, TGCVector3.Empty);
+            sphere.AlphaBlendEnable = true;
+            sphere.updateValues();
+            sphere.Transform = TGCMatrix.Scaling(new TGCVector3(radius, radius, radius));
+        }
+
+        private void InitializeArrows()
+        {
+            fromArrow = new TgcArrow();
+            fromArrow.BodyColor = Color.DarkBlue;
+            fromArrow.HeadColor = Color.Blue;
+            fromArrow.HeadSize = new TGCVector2(0.2f, 0.2f);
+            fromArrow.Thickness = 0.1f;
+            fromArrow.PStart = TGCVector3.Empty;
+
+            toArrow = new TgcArrow();
+            toArrow.BodyColor = Color.DarkRed;
+            toArrow.HeadColor = Color.Red;
+            toArrow.HeadSize = new TGCVector2(0.2f, 0.2f);
+            toArrow.Thickness = 0.1f;
+            toArrow.PStart = TGCVector3.Empty;
+
+            crossArrow = new TgcArrow();
+            crossArrow.BodyColor = Color.DarkGoldenrod;
+            crossArrow.HeadColor = Color.Yellow;
+            crossArrow.HeadSize = new TGCVector2(0.2f, 0.2f);
+            crossArrow.Thickness = 0.1f;
+            crossArrow.PStart = TGCVector3.Empty;
+        }
+
+        private void UpdateArrows()
+        {
+            if (dragging)
+            {
+                toArrow.PEnd = currentPick;
+                toArrow.updateValues();
+
+                var cross = TGCVector3.Cross(fromDrag, currentPick);
+                cross.Normalize();
+                cross.Scale(-radius);
+                crossArrow.PEnd = cross;
+                crossArrow.updateValues();
+            }
+            else
+            {
+                fromArrow.PEnd = currentPick;
+                fromArrow.updateValues();
+
+                toArrow.PEnd = TGCVector3.Empty;
+                toArrow.updateValues();
+
+                toArrow.PEnd = TGCVector3.Empty;
+                toArrow.updateValues();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed Quaterion identity, was being done incorrectly.
Also fixed the quaternion example, changed its 3D models to a more orientable one.  Fixed the generation of its quaternion based on three axes.
Added a trackball example to help illustrate how quaternions work.